### PR TITLE
vup link-local-dependencies from 1.0.3 to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plaidev/link-local-dependencies",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "./src/index.ts",
   "repository": "git@github.com:plaidev/link-local-dependencies.git",
   "author": "RyosukeCla <ryosukeclarinet@gmail.com>",


### PR DESCRIPTION
link-local-dependenciesの1.0.3がどういうわけかなくなってしまったので、1.0.4をpublishしてみる。